### PR TITLE
CI: Add Coveralls coverage upload to GitHub Actions

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -29,3 +29,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         timeout-minutes: 15
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        if: matrix.os == 'ubuntu-latest' && matrix.smalltalk == 'Pharo64-14'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -8,7 +8,8 @@ SmalltalkCISpec {
   ],
   #testing : {
     #coverage : {
-      #packages : [ 'Containers-Trie' ]
+      #packages : [ 'Containers-Trie' ],
+      #format : #lcov
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ can only load the collection they need without 100 of related collections.
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)]()
 [![Pharo version](https://img.shields.io/badge/Pharo-7.0-%23aac9ff.svg)](https://pharo.org/download)
 [![Pharo version](https://img.shields.io/badge/Pharo-8.0-%23aac9ff.svg)](https://pharo.org/download)
-
+[![Coverage Status](https://coveralls.io/repos/github/pharo-containers/Containers-Trie/badge.svg?branch=master)](https://coveralls.io/github/pharo-containers/Containers-Trie?branch=master)
 
 ## Loading
 


### PR DESCRIPTION
Fixes #5 

This PR sets up coverage reporting for the repository using the existing `smalltalkCI` configuration

**Changes:**
* **matrix.yml:** Added a step to upload the coverage generated by `smalltalkCI` to Coveralls via the `coverallsapp/github-action@v2` action
* **Optimized CI Run:** Constrained the coverage upload to run only once per matrix build to prevent redundant uploads to the Coveralls server
* **README.md:** Added the Coveralls coverage badge to the badges section so the current coverage status is easily visible
* **.smalltalk.ston:** Added `#format : #lcov` to the testing coverage configuration so the GitHub Action can correctly parse the generated output.